### PR TITLE
Add github Issues as the bug tracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,6 +39,10 @@ WriteMakefile(
         url  => 'https://github.com/yuki-kimoto/SPVM-Regex.git',
         web  => 'https://github.com/yuki-kimoto/SPVM-Regex',
       },
+      bugtracker => {
+        web => "https://github.com/yuki-kimoto/SPVM-Regex/issues",
+      },
+
     },
   },
   NORECURS => 1,


### PR DESCRIPTION
I am a participant of Mr Szabo's Perl open source development course. I found SPVM a very interesting project and hope to be able to take part in it. I am studying the code base.

Add the github issue as the issue tracker is an assignment of Mr Szabo's course. I saw that you are already using github Issue. I hope this pull request is useful.

Thanks.